### PR TITLE
feat: Add validation for capacity in RequestExperienceDto

### DIFF
--- a/src/main/java/com/igrowker/wander/dto/experience/RequestExperienceDto.java
+++ b/src/main/java/com/igrowker/wander/dto/experience/RequestExperienceDto.java
@@ -2,6 +2,8 @@ package com.igrowker.wander.dto.experience;
 
 import java.util.List;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -36,5 +38,7 @@ public class RequestExperienceDto {
     private double rating;
 
     @NotNull(message= "La capacidad debe ser al menos 1.")
+    @Min(value = 1, message = "La capacidad debe ser al menos 1.")
+    @Max(value = 50, message = "La capacidad no puede ser mayor de 50.")
     private int capacity;
 }

--- a/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
+++ b/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
@@ -97,7 +97,7 @@ public class ExperienceServiceImpl implements ExperienceService {
 	    if (newExperienceData.getTags() != null) {
 	        existingExperience.setTags(newExperienceData.getTags());
 	    }
-	    if (newExperienceData.getCapacity() > 0) {
+	    if (newExperienceData.getCapacity() > 0 && newExperienceData.getCapacity() <= 50) {
 	        existingExperience.setCapacity(newExperienceData.getCapacity());
 	    }
 


### PR DESCRIPTION
- Added @Min and @Max annotations to enforce capacity values between 1 and 50 in RequestExperienceDto.
- Validate the same logic in updateExperience on ExperienceServiceImpl