### PR TITLE
Feature get reviews by experience

### DIFF
--- a/src/main/java/com/igrowker/wander/controller/ReviewController.java
+++ b/src/main/java/com/igrowker/wander/controller/ReviewController.java
@@ -2,17 +2,17 @@ package com.igrowker.wander.controller;
 
 import javax.validation.Valid;
 
+import com.igrowker.wander.dto.review.ResponseReviewDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.igrowker.wander.dto.review.RequestReviewDto;
-import com.igrowker.wander.entity.ReviewEntity;
+
 import com.igrowker.wander.service.ReviewService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/reviews")
@@ -20,6 +20,18 @@ public class ReviewController {
 
     @Autowired
     private ReviewService reviewService;
+
+    /**
+     * Get all the reviews for a specific experience
+     *
+     * @param idExperience experience identifier
+     * @return list of reviews by experience id
+     */
+    @GetMapping("/experience/{idExperience}")
+    public ResponseEntity<List<ResponseReviewDto>> getReviewsByExperience(@PathVariable String idExperience) {
+        List<ResponseReviewDto> reviews = reviewService.getReviewsByExperience(idExperience);
+        return ResponseEntity.ok(reviews);
+    }
 
     /**
      * Endpoint to add a new review

--- a/src/main/java/com/igrowker/wander/dto/review/ResponseReviewDto.java
+++ b/src/main/java/com/igrowker/wander/dto/review/ResponseReviewDto.java
@@ -1,0 +1,18 @@
+package com.igrowker.wander.dto.review;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseReviewDto {
+    private String id;
+    private String userId;
+    private Double rating;
+    private String comment;
+    private Date createdAt;
+}

--- a/src/main/java/com/igrowker/wander/entity/ReviewEntity.java
+++ b/src/main/java/com/igrowker/wander/entity/ReviewEntity.java
@@ -3,6 +3,7 @@ package com.igrowker.wander.entity;
 import java.util.Date;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.AllArgsConstructor;
@@ -13,7 +14,8 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Document(collection = "reviews") 
+@Document(collection = "reviews")
+@CompoundIndex(name = "experience_createdAt_idx", def = "{'experienceId': 1, 'createdAt': -1}")
 public class ReviewEntity {
 
 	@Id

--- a/src/main/java/com/igrowker/wander/repository/ReviewRepository.java
+++ b/src/main/java/com/igrowker/wander/repository/ReviewRepository.java
@@ -10,5 +10,6 @@ import com.igrowker.wander.entity.ReviewEntity;
 @EnableMongoRepositories(basePackages = "com.igrowker.wander.repository")
 public interface ReviewRepository extends MongoRepository<ReviewEntity, String>{
 
+    List<ReviewEntity> findByExperienceIdOrderByCreatedAtDesc(String experienceId);
     List<ReviewEntity> findByExperienceId(String experienceId);
 }

--- a/src/main/java/com/igrowker/wander/security/SecurityConfiguration.java
+++ b/src/main/java/com/igrowker/wander/security/SecurityConfiguration.java
@@ -32,7 +32,8 @@ public class SecurityConfiguration {
                         .requestMatchers("/api/autenticacion/**", "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html",
-                                "/api/users/register").permitAll()
+                                "/api/users/register",
+                                "/reviews/experience/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session

--- a/src/main/java/com/igrowker/wander/service/ReviewService.java
+++ b/src/main/java/com/igrowker/wander/service/ReviewService.java
@@ -1,9 +1,13 @@
 package com.igrowker.wander.service;
 
 import com.igrowker.wander.dto.review.RequestReviewDto;
+import com.igrowker.wander.dto.review.ResponseReviewDto;
 import com.igrowker.wander.entity.ReviewEntity;
+
+import java.util.List;
 
 public interface ReviewService {
 
+    List<ResponseReviewDto> getReviewsByExperience(String experienceId);
     ReviewEntity addReview(RequestReviewDto review);
 }

--- a/src/main/java/com/igrowker/wander/serviceimpl/ReviewServiceImpl.java
+++ b/src/main/java/com/igrowker/wander/serviceimpl/ReviewServiceImpl.java
@@ -1,7 +1,9 @@
 package com.igrowker.wander.serviceimpl;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import com.igrowker.wander.dto.review.ResponseReviewDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +24,18 @@ public class ReviewServiceImpl implements ReviewService{
 
     @Autowired
     private ExperienceRepository experienceRepository;
+
+    @Override
+    public List<ResponseReviewDto> getReviewsByExperience(String experienceId) {
+        if (experienceId == null || experienceId.isEmpty()) {
+            throw new IllegalArgumentException("Experience id can't be null or empty.");
+        }
+        List<ReviewEntity> reviews = reviewRepository.findByExperienceIdOrderByCreatedAtDesc(experienceId);
+
+        return reviews.stream()
+                .map(this::convertToResponseDto)
+                .collect(Collectors.toList());
+    }
 
     @Override
     public ReviewEntity addReview(@Valid RequestReviewDto reviewDto) {
@@ -48,4 +62,15 @@ public class ReviewServiceImpl implements ReviewService{
 
         return savedReview;
     }
+
+    private ResponseReviewDto convertToResponseDto(ReviewEntity review) {
+        ResponseReviewDto responseDto = new ResponseReviewDto();
+        responseDto.setId(review.getId());
+        responseDto.setUserId(review.getUserId());
+        responseDto.setRating(review.getRating());
+        responseDto.setComment(review.getComment());
+        responseDto.setCreatedAt(review.getCreatedAt());
+        return responseDto;
+    }
+
 }


### PR DESCRIPTION
Este PR implementa un nuevo endpoint para obtener las reviews de una experiencia específica. Los principales cambios incluyen:

- **Endpoint**: `GET /reviews/experience/{idExperience}`
  - Este endpoint permite obtener todas las reviews de una experiencia específica, ordenadas de la más reciente a la más antigua.
  - Devuelve una lista de objetos `ResponseReviewDto`, que contienen información de cada review.

### Funcionalidad Implementada

- **Controller**: 
  - Se implementó el controlador `ReviewController` con el endpoint mencionado, que llama al servicio para obtener las reviews de la experiencia.
  
- **Service**:
  - El servicio `ReviewServiceImpl` contiene la lógica para recuperar las reviews desde la base de datos utilizando el repositorio. Si no existen reviews, se devuelve una lista vacía.
  - El servicio también maneja las excepciones, que son gestionadas por el `GlobalExceptionHandler`.

### Cambios en la Seguridad

- **Ruta pública**: El endpoint para obtener las reviews por experiencia ahora está accesible sin autenticación. Esto se configuró en el archivo `SecurityConfiguration`.
