### PR TITLE
Make get Experience endpoints public

### DIFF
--- a/src/main/java/com/igrowker/wander/security/SecurityConfiguration.java
+++ b/src/main/java/com/igrowker/wander/security/SecurityConfiguration.java
@@ -3,6 +3,7 @@ package com.igrowker.wander.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -29,6 +30,7 @@ public class SecurityConfiguration {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.GET, "/experiences/**").permitAll()
                         .requestMatchers("/api/autenticacion/**", "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html",


### PR DESCRIPTION
Este cambio permite el acceso público a los endpoints `GET` de **Experience**, asegurando que cualquier solicitud a las rutas relacionadas con experiencias sea accesible sin necesidad de autenticación. La configuración de Spring Security se ha actualizado utilizando el método `requestMatchers(HttpMethod.GET, "/experiences/**").permitAll()` para permitir estas solicitudes **GET** específicas.

## Cambios realizados:

- Se modificó la configuración de Spring Security para permitir el acceso sin autenticación a los endpoints `GET` de la entidad **Experience**.
  
- El siguiente código ha sido añadido a la configuración de seguridad:

  ```java
  .requestMatchers(HttpMethod.GET, "/experiences/**").permitAll()