### PR TITLE
feat: implement multiple tags search in ExperienceRepository and

### DIFF
--- a/src/main/java/com/igrowker/wander/controller/ExperienceController.java
+++ b/src/main/java/com/igrowker/wander/controller/ExperienceController.java
@@ -84,5 +84,17 @@ public class ExperienceController {
 	    List<ExperienceEntity> experiences = experienceService.getExperiencesByTag(tag);
 	    return ResponseEntity.ok(experiences);
 	}
-
+	
+	@GetMapping("/tags")
+	public ResponseEntity<List<ExperienceEntity>> getExperiencesByMultipleTags(
+	        @RequestParam List<String> tags) {
+	    try {
+	        List<ExperienceEntity> experiences = experienceService.getExperiencesByMultipleTags(tags);
+	        return ResponseEntity.ok(experiences);
+	    } catch (IllegalArgumentException e) {
+	        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+	    } catch (Exception e) {
+	        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+	    }
+	}
 }

--- a/src/main/java/com/igrowker/wander/repository/ExperienceRepository.java
+++ b/src/main/java/com/igrowker/wander/repository/ExperienceRepository.java
@@ -27,5 +27,9 @@ public interface ExperienceRepository extends MongoRepository<ExperienceEntity, 
     List<ExperienceEntity> findAll();
     
     List<ExperienceEntity> findByTagsContaining(String tag);
+    
+    List<ExperienceEntity> findByTagsIn(List<String> tags);
+
+
 
 }

--- a/src/main/java/com/igrowker/wander/service/ExperienceService.java
+++ b/src/main/java/com/igrowker/wander/service/ExperienceService.java
@@ -16,4 +16,7 @@ public interface ExperienceService {
     ExperienceEntity updateExperience(String id, ExperienceEntity updatedExperience);
     
     List<ExperienceEntity> getExperiencesByTag(String tag);
+    
+    List<ExperienceEntity> getExperiencesByMultipleTags(List<String> tags);
+
 }

--- a/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
+++ b/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
@@ -128,4 +128,11 @@ public class ExperienceServiceImpl implements ExperienceService {
 	    return experienceRepository.findByTagsContaining(tag);
 	}
 
+	@Override
+	public List<ExperienceEntity> getExperiencesByMultipleTags(List<String> tags) {
+	    if (tags == null || tags.isEmpty()) {
+	        throw new IllegalArgumentException("La lista de tags no puede estar vacía.");
+	    }
+	    return experienceRepository.findByTagsIn(tags);
+	}
 }


### PR DESCRIPTION
### Implementación de búsqueda por múltiples tags en experiencias

#### Descripción
Este pull request agrega la funcionalidad de búsqueda de experiencias mediante múltiples tags. Se han realizado las siguientes modificaciones:

- **Repositorio**:  
  - Se añadió el método `findByTagsIn` en `ExperienceRepository` para permitir la búsqueda de experiencias por múltiples tags.

- **Servicio**:  
  - Se actualizó `ExperienceService` y `ExperienceServiceImpl` para incluir el nuevo método `getExperiencesByMultipleTags`, encargado de la lógica de búsqueda.

- **Controlador**:  
  - Se creó un nuevo endpoint en `ExperienceController` con la ruta `/experiences/tags`, que permite realizar búsquedas enviando una lista de tags como parámetros.

#### Consideraciones
Esta implementación no afecta la búsqueda de experiencias mediante otros filtros, ya que el nuevo método es independiente de los existentes.