### PR TITLE
Feature: get experiences by host

### DIFF
--- a/src/main/java/com/igrowker/wander/controller/ExperienceController.java
+++ b/src/main/java/com/igrowker/wander/controller/ExperienceController.java
@@ -1,6 +1,7 @@
 package com.igrowker.wander.controller;
 
 import com.igrowker.wander.dto.experience.RequestExperienceDto;
+import com.igrowker.wander.dto.experience.ResponseExperienceDto;
 import com.igrowker.wander.entity.ExperienceEntity;
 import com.igrowker.wander.entity.User;
 import com.igrowker.wander.service.ExperienceService;
@@ -96,5 +97,17 @@ public class ExperienceController {
 	    } catch (Exception e) {
 	        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
 	    }
+	}
+
+	/**
+	 * Retrieves all experiences for a specific host
+	 *
+	 * @param hostId the identifier of the host
+	 * @return List of ResponseExperienceDto representing the experiences associated with the specified host
+	 */
+	@GetMapping("/host/{hostId}")
+	public ResponseEntity<List<ResponseExperienceDto>> getExperiencesByHost(@PathVariable String hostId) {
+		List<ResponseExperienceDto> responseDtos = experienceService.getExperiencesByHost(hostId);
+		return ResponseEntity.ok(responseDtos);
 	}
 }

--- a/src/main/java/com/igrowker/wander/dto/experience/ResponseExperienceDto.java
+++ b/src/main/java/com/igrowker/wander/dto/experience/ResponseExperienceDto.java
@@ -1,0 +1,26 @@
+package com.igrowker.wander.dto.experience;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseExperienceDto {
+    private String id;
+    private String title;
+    private String description;
+    private String location;
+    private String hostId;
+    private Double price;
+    private List<String> availabilityDates;
+    private List<String> tags;
+    private Double rating;
+    private int capacity;
+    private Date createdAt;
+    private boolean status;
+}

--- a/src/main/java/com/igrowker/wander/repository/ExperienceRepository.java
+++ b/src/main/java/com/igrowker/wander/repository/ExperienceRepository.java
@@ -30,6 +30,6 @@ public interface ExperienceRepository extends MongoRepository<ExperienceEntity, 
     
     List<ExperienceEntity> findByTagsIn(List<String> tags);
 
-
+    List<ExperienceEntity> findByHostId(String hostId);
 
 }

--- a/src/main/java/com/igrowker/wander/service/ExperienceService.java
+++ b/src/main/java/com/igrowker/wander/service/ExperienceService.java
@@ -3,6 +3,7 @@ package com.igrowker.wander.service;
 import java.util.List;
 
 import com.igrowker.wander.dto.experience.RequestExperienceDto;
+import com.igrowker.wander.dto.experience.ResponseExperienceDto;
 import com.igrowker.wander.entity.ExperienceEntity;
 import com.igrowker.wander.entity.User;
 
@@ -18,5 +19,7 @@ public interface ExperienceService {
     List<ExperienceEntity> getExperiencesByTag(String tag);
     
     List<ExperienceEntity> getExperiencesByMultipleTags(List<String> tags);
+
+    List<ResponseExperienceDto> getExperiencesByHost(String hostId);
 
 }

--- a/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
+++ b/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
@@ -1,7 +1,11 @@
 package com.igrowker.wander.serviceimpl;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import com.igrowker.wander.dto.experience.ResponseExperienceDto;
+import com.igrowker.wander.exception.ResourceNotFoundException;
+import com.igrowker.wander.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -18,6 +22,9 @@ public class ExperienceServiceImpl implements ExperienceService {
 
 	@Autowired
 	private ExperienceRepository experienceRepository;
+
+	@Autowired
+	private UserRepository userRepository;
 
 	@Override 
 	public ExperienceEntity createExperience(RequestExperienceDto requestExperienceDto, User user) {
@@ -135,4 +142,37 @@ public class ExperienceServiceImpl implements ExperienceService {
 	    }
 	    return experienceRepository.findByTagsIn(tags);
 	}
+
+	@Override
+	public List<ResponseExperienceDto> getExperiencesByHost(String hostId) {
+		userRepository.findById(hostId)
+				.orElseThrow(() -> new ResourceNotFoundException("Host with id: " + hostId + " not found"));
+
+		List<ExperienceEntity> experiences = experienceRepository.findByHostId(hostId);
+
+		List<ResponseExperienceDto> dtos = new ArrayList<>();
+		for (ExperienceEntity experience : experiences) {
+			dtos.add(convertToResponseDto(experience));
+		}
+		return dtos;
+	}
+
+	private ResponseExperienceDto convertToResponseDto(ExperienceEntity experience) {
+		return new ResponseExperienceDto(
+				experience.getId(),
+				experience.getTitle(),
+				experience.getDescription(),
+				experience.getLocation(),
+				experience.getHostId(),
+				experience.getPrice(),
+				experience.getAvailabilityDates(),
+				experience.getTags(),
+				experience.getRating(),
+				experience.getCapacity(),
+				experience.getCreatedAt(),
+				experience.isStatus()
+		);
+	}
+
+
 }


### PR DESCRIPTION
Implementación del endpoint para obtener las experiencias de un host.
### Cambios realizados:
- Se creó el endpoint `GET /experiences/host/{hostId}` para obtener todas las experiencias de un host específico, identificado por su `hostId`.
- El controlador recibe el parámetro `hostId` como **path variable** y lo utiliza para consultar las experiencias asociadas a ese host.
- Se implementó la lógica para:
  - Validar que el `hostId` exista y obtener las experiencias correspondientes.
  - Retornar una lista de `ResponseExperienceDto` que contienen los detalles de las experiencias.
  - Si no se encuentran experiencias para el `hostId` especificado, devuelve una lista vacía.
  - Si el `hostId` no existe en la base de datos, se lanza una excepción `ResourceNotFoundException`