### PR TITLE
feat: updated location field in ExperienceEntity to handle List<String>

### DIFF
--- a/src/main/java/com/igrowker/wander/controller/ExperienceController.java
+++ b/src/main/java/com/igrowker/wander/controller/ExperienceController.java
@@ -40,16 +40,19 @@ public class ExperienceController {
 
 	@GetMapping
 	public ResponseEntity<List<ExperienceEntity>> getExperiences(
-	        @RequestParam(required = false) String location,
+	        @RequestParam(required = false) List<String> location,
 	        @RequestParam(required = false) Double maxPrice,
 	        @RequestParam(required = false) String title) {
 	    try {
 	        List<ExperienceEntity> experiences = experienceService.getExperiences(location, maxPrice, title);
 	        return ResponseEntity.ok(experiences);
+	    } catch (IllegalArgumentException e) {
+	        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
 	    } catch (Exception e) {
-	        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+	        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
 	    }
 	}
+
 
 
 	@GetMapping("/{id}")

--- a/src/main/java/com/igrowker/wander/dto/experience/RequestExperienceDto.java
+++ b/src/main/java/com/igrowker/wander/dto/experience/RequestExperienceDto.java
@@ -22,8 +22,9 @@ public class RequestExperienceDto {
     @NotBlank(message= "La descripción de la experiencia es obligatoria y debe tener entre 10 y 500 caracteres.")
     private String description;
 
-    @NotBlank(message= "La ubicación de la experiencia es obligatoria.")
-    private String location;
+    @NotNull(message = "La ubicación de la experiencia es obligatoria.")
+    @Size(min = 1, message = "Debe proporcionar al menos un campo de ubicación.")
+    private List<@NotBlank(message = "Cada elemento de la ubicación debe ser un texto válido.") String> location;
 
     @NotBlank
     private String hostId; 

--- a/src/main/java/com/igrowker/wander/entity/ExperienceEntity.java
+++ b/src/main/java/com/igrowker/wander/entity/ExperienceEntity.java
@@ -24,7 +24,7 @@ public class ExperienceEntity {
 
     private String description;
 
-    private String location;
+    private List<String> location;
 
     @Field("hostId") 
     private String hostId; 

--- a/src/main/java/com/igrowker/wander/repository/ExperienceRepository.java
+++ b/src/main/java/com/igrowker/wander/repository/ExperienceRepository.java
@@ -10,26 +10,23 @@ import com.igrowker.wander.entity.ExperienceEntity;
 @EnableMongoRepositories(basePackages = "com.igrowker.wander.repository")
 public interface ExperienceRepository extends MongoRepository<ExperienceEntity, String> {
 
-    List<ExperienceEntity> findByLocationAndPriceLessThanEqualAndTitleContaining(String location, Double maxPrice, String title);
-    
-    List<ExperienceEntity> findByLocationAndPriceLessThanEqual(String location, Double maxPrice);
+	List<ExperienceEntity> findByLocationContainsAndPriceLessThanEqualAndTitleContaining(List<String> location, Double maxPrice, String title);
 
-    List<ExperienceEntity> findByLocationAndTitleContaining(String location, String title);
+    List<ExperienceEntity> findByLocationContainsAndPriceLessThanEqual(List<String> location, Double maxPrice);
+
+    List<ExperienceEntity> findByLocationContainsAndTitleContaining(List<String> location, String title);
 
     List<ExperienceEntity> findByPriceLessThanEqualAndTitleContaining(Double maxPrice, String title);
 
     List<ExperienceEntity> findByTitleContaining(String title);
 
-    List<ExperienceEntity> findByLocation(String location);
+    List<ExperienceEntity> findByLocationContains(List<String> location);
 
     List<ExperienceEntity> findByPriceLessThanEqual(Double maxPrice);
 
     List<ExperienceEntity> findAll();
-    
+
     List<ExperienceEntity> findByTagsContaining(String tag);
-    
+
     List<ExperienceEntity> findByTagsIn(List<String> tags);
-
-
-
 }

--- a/src/main/java/com/igrowker/wander/service/ExperienceService.java
+++ b/src/main/java/com/igrowker/wander/service/ExperienceService.java
@@ -9,7 +9,9 @@ import com.igrowker.wander.entity.User;
 public interface ExperienceService {
 	ExperienceEntity createExperience(RequestExperienceDto experience, User user);
     
-    List<ExperienceEntity> getExperiences(String location, Double maxPrice, String title);
+    List<ExperienceEntity> getExperiences(List<String> location, Double maxPrice, String title);
+    
+    List<ExperienceEntity> getExperiences(List<String> location, Double maxPrice);
 
     ExperienceEntity getExperienceById(String id);
 

--- a/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
+++ b/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
@@ -40,23 +40,22 @@ public class ExperienceServiceImpl implements ExperienceService {
 	}
 
 	@Override
-
-	public List<ExperienceEntity> getExperiences(String location, Double maxPrice, String title) {
-	    if (location != null && maxPrice != null && title != null) {
-	        // Filtro por ubicación, precio y título
-	        return experienceRepository.findByLocationAndPriceLessThanEqualAndTitleContaining(location, maxPrice, title);
-	    } else if (location != null && title != null) {
-	        // Filtro por ubicación y título
-	        return experienceRepository.findByLocationAndTitleContaining(location, title);
+	public List<ExperienceEntity> getExperiences(List<String> location, Double maxPrice, String title) {
+	    if (location != null && !location.isEmpty() && maxPrice != null && title != null) {
+	        // Filtro por ubicación (país), precio y título
+	        return experienceRepository.findByLocationContainsAndPriceLessThanEqualAndTitleContaining(location, maxPrice, title);
+	    } else if (location != null && !location.isEmpty() && title != null) {
+	        // Filtro por ubicación (país) y título
+	        return experienceRepository.findByLocationContainsAndTitleContaining(location, title);
 	    } else if (maxPrice != null && title != null) {
 	        // Filtro por precio y título
 	        return experienceRepository.findByPriceLessThanEqualAndTitleContaining(maxPrice, title);
-	    } else if (location != null && maxPrice != null) {
-	        // Filtro por ubicación y precio
-	        return experienceRepository.findByLocationAndPriceLessThanEqual(location, maxPrice);
-	    } else if (location != null) {
-	        // Filtro por ubicación
-	        return experienceRepository.findByLocation(location);
+	    } else if (location != null && !location.isEmpty() && maxPrice != null) {
+	        // Filtro por ubicación (país) y precio
+	        return experienceRepository.findByLocationContainsAndPriceLessThanEqual(location, maxPrice);
+	    } else if (location != null && !location.isEmpty()) {
+	        // Filtro por ubicación (país)
+	        return experienceRepository.findByLocationContains(location);
 	    } else if (maxPrice != null) {
 	        // Filtro por precio
 	        return experienceRepository.findByPriceLessThanEqual(maxPrice);
@@ -69,17 +68,19 @@ public class ExperienceServiceImpl implements ExperienceService {
 	    }
 	}
 
-    public List<ExperienceEntity> getExperiences(String location, Double maxPrice) {
-        if (location != null && maxPrice != null) {
-            return experienceRepository.findByLocationAndPriceLessThanEqual(location, maxPrice);
-        } else if (location != null) {
-            return experienceRepository.findByLocation(location);
-        } else if (maxPrice != null) {
-            return experienceRepository.findByPriceLessThanEqual(maxPrice);
-        } else {
-            return experienceRepository.findAll();
-        }
-    }
+	@Override
+	public List<ExperienceEntity> getExperiences(List<String> location, Double maxPrice) {
+	    if (location != null && maxPrice != null) {
+	        return experienceRepository.findByLocationContainsAndPriceLessThanEqual(location, maxPrice);
+	    } else if (location != null) {
+	        return experienceRepository.findByLocationContains(location);
+	    } else if (maxPrice != null) {
+	        return experienceRepository.findByPriceLessThanEqual(maxPrice);
+	    } else {
+	        return experienceRepository.findAll();
+	    }
+	}
+
 
 	
 	@Override


### PR DESCRIPTION
### Resumen del trabajo realizado:

- Se ha modificado el campo `location` en la entidad `ExperienceEntity` para que ahora maneje una lista de cadenas (`List<String>`) en lugar de un único valor `String`.  
- Se han actualizado las siguientes partes del código para reflejar este cambio:
  - **Entidad**: Cambio de tipo de dato y ajustes en los métodos correspondientes.
  - **DTO**: Modificado para aceptar y validar una lista en lugar de una cadena única.
  - **Repositorio**: Ajuste de los métodos de consulta para que sean compatibles con la nueva estructura del campo `location`.
  - **Servicio**: Refactorización de la lógica en los métodos de filtrado por ubicación para trabajar con listas de cadenas.
  - **Controller**: Adaptación del endpoint correspondiente para manejar el nuevo formato de ubicación.

Estos cambios permiten mayor flexibilidad al filtrar por ubicaciones específicas en varios niveles (país, ciudad, etc.). El código ha sido probado y es funcional.

### IMPORTANTE
### Nota sobre los tests:

Actualmente, los tests relacionados con las búsquedas por ubicación están fallando debido al cambio en la estructura del campo `location`, que ahora maneja una lista de cadenas (`List<String>`) en lugar de un único valor `String`. Este cambio impacta en los casos de prueba existentes, ya que estos fueron diseñados para la estructura anterior.

La situación ya ha sido comunicada a la compañera encargada de los tests, quien está al tanto y se encargará de actualizarlos para que sean compatibles con la nueva implementación. Este cambio no afecta al funcionamiento del código, que ha sido probado de manera manual y es funcional.
