### PR TITLE
Feature: delete own review functionality

### DIFF
--- a/src/main/java/com/igrowker/wander/controller/ReviewController.java
+++ b/src/main/java/com/igrowker/wander/controller/ReviewController.java
@@ -50,4 +50,15 @@ public class ReviewController {
                     .body("Error adding the review: " + e.getMessage());
         }
     }
+
+    /**
+     * Endpoint to delete a review by id
+     * @param id id of the review to be deleted
+     * @return Response indicating if the review was deleted successfully
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResponseReviewDto> deleteReview(@PathVariable String id) {
+        ResponseReviewDto deletedReview = reviewService.deleteReview(id);
+        return ResponseEntity.ok(deletedReview);
+    }
 }	

--- a/src/main/java/com/igrowker/wander/service/ReviewService.java
+++ b/src/main/java/com/igrowker/wander/service/ReviewService.java
@@ -10,4 +10,5 @@ public interface ReviewService {
 
     List<ResponseReviewDto> getReviewsByExperience(String experienceId);
     ReviewEntity addReview(RequestReviewDto review);
+    ResponseReviewDto deleteReview(String id);
 }


### PR DESCRIPTION
Este PR implementa la funcionalidad para **eliminar reseñas** de usuarios en el sistema.

- **Método `deleteReview` en el servicio (`ReviewService`)**:
  - Se agrega lógica para eliminar una reseña por su id.
  - Se valida que la reseña exista en la base de datos.
  - Se comprueba que el usuario autenticado sea el autor de la reseña.
  - Los **proveedores** no pueden eliminar reseñas.
  - La reseña se elimina si el usuario es el autor y no es un proveedor.
  - En caso de que no se cumplan las condiciones, se lanza una excepción (`InvalidUserCredentialsException` o `IllegalArgumentException`).

- **Controlador `ReviewController`**:
  - Se agrega un endpoint `DELETE` en la ruta `/reviews/{id}`.
  - Endpoint recibe el `id` de la reseña a eliminar y llama al servicio.
  - El endpoint devuelve un `ResponseEntity` con un **`200 OK`** y el **DTO de la reseña eliminada** como confirmación de la operación exitosa.


### Notas

- Se ha asegurado que los usuarios **PROVIDERS** no puedan eliminar reseñas.
- Si se intenta eliminar una reseña que no pertenece al usuario autenticado, se lanza una excepción de tipo `InvalidUserCredentialsException`.