### PR TITLE
feat: add health endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
 			<groupId>org.springframework.session</groupId>
 			<artifactId>spring-session-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+			<version>3.4.0</version>
+		</dependency>
 
 		<!-- Database -->
 		<dependency>

--- a/src/main/java/com/igrowker/wander/security/SecurityConfiguration.java
+++ b/src/main/java/com/igrowker/wander/security/SecurityConfiguration.java
@@ -33,6 +33,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/experiences/**").permitAll()
                         .requestMatchers("/api/autenticacion/**", "/swagger-ui/**",
                                 "/v3/api-docs/**",
+                                "/actuator/health",
                                 "/swagger-ui.html",
                                 "/api/users/register",
                                 "/reviews/experience/**").permitAll()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,5 +21,7 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.ssl.trust=smtp.gmail.com
 
+management.endpoints.web.exposure.include=health
+
 # Cargar configuraciones desde archivo .env
 spring.config.import=optional:file:.env[.properties]


### PR DESCRIPTION
Se agrego el endpoint /health utilizando Spring Actuator para monitorear el estado de la aplicación. Con esta implementación, la aplicación expone automáticamente un endpoint que devuelve el estado de salud actual. Esto facilita la supervisión del estado de la app en entornos de producción, ya que Spring Actuator ofrece funcionalidades adicionales como métricas de rendimiento y detalles sobre los componentes de la aplicación.

La configuración se realizó agregando la dependencia spring-boot-starter-actuator y habilitando el endpoint /actuator/health en el archivo de configuración application.properties. Ademas se sumo la ruta dentro de la configuración de Spring Security.