### PR TITLE
fix(experiences): ensure filtering by country and city works correctly

### DIFF
--- a/src/main/java/com/igrowker/wander/repository/ExperienceRepository.java
+++ b/src/main/java/com/igrowker/wander/repository/ExperienceRepository.java
@@ -31,6 +31,9 @@ public interface ExperienceRepository extends MongoRepository<ExperienceEntity, 
 
     @Query("{ 'location.0': ?0, 'title': { $regex: ?1, $options: 'i' } }")
     List<ExperienceEntity> findByCountryAndTitleContaining(String country, String title);
+    
+    @Query("{ 'location.0': ?0, 'location.1': ?1 }")
+    List<ExperienceEntity> findByCountryAndCity(String country, String city);
 
     @Query("{ 'location.0': ?0 }")
     List<ExperienceEntity> findByCountry(String country);

--- a/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
+++ b/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
@@ -71,6 +71,10 @@ public class ExperienceServiceImpl implements ExperienceService {
             return experienceRepository.findByTagsIn(tags);
         }
         
+        if (country != null && !country.isEmpty() && city != null) {
+            return experienceRepository.findByCountryAndCity(country, city);
+        }
+        
         if (city != null) {
             if (maxPrice != null && title != null) {
                 return experienceRepository.findByCityAndPriceLessThanEqualAndTitleContaining(city, maxPrice, title);


### PR DESCRIPTION
# Corrección: Filtrado por País y Ciudad en Experiencias

## Descripción
El compañero Gabriel me informa de un problema en el filtro. Acciones realizadas:
Se corrigió el comportamiento del filtrado de experiencias para asegurar que las combinaciones de **país** y **ciudad** funcionen correctamente. Ahora se prioriza la combinación específica cuando ambos filtros son proporcionados.

## Cambios
- **Repositorio**: Se añadió un método para filtrar simultáneamente por país y ciudad.
- **Servicio**: Se actualizó `ExperienceServiceImpl` para manejar correctamente combinaciones de filtros.
- **Pruebas**: Validación de casos positivos y negativos, asegurando resultados precisos o nulos según corresponda.

## Resolución
Este cambio soluciona inconsistencias al filtrar por valores incompatibles de país y ciudad.
