### PR TITLE
feat: add user info to review responses

### DIFF
--- a/src/main/java/com/igrowker/wander/dto/review/ResponseReviewDto.java
+++ b/src/main/java/com/igrowker/wander/dto/review/ResponseReviewDto.java
@@ -12,6 +12,8 @@ import java.util.Date;
 public class ResponseReviewDto {
     private String id;
     private String userId;
+    private String userAvatar;
+    private String userName;
     private Double rating;
     private String comment;
     private Date createdAt;

--- a/src/main/java/com/igrowker/wander/entity/ReviewEntity.java
+++ b/src/main/java/com/igrowker/wander/entity/ReviewEntity.java
@@ -24,10 +24,16 @@ public class ReviewEntity {
 	private String experienceId;
 	
 	private String userId;
+
+	private String userAvatar;
+
+	private String userName;
 	
 	private Double rating; 
 	
 	private String comment;
 	
 	private Date createdAt = new Date();
+
+
 }

--- a/src/main/java/com/igrowker/wander/serviceimpl/ReviewServiceImpl.java
+++ b/src/main/java/com/igrowker/wander/serviceimpl/ReviewServiceImpl.java
@@ -22,9 +22,9 @@ import com.igrowker.wander.service.ReviewService;
 import jakarta.validation.Valid;
 
 @Service
-public class ReviewServiceImpl implements ReviewService{
+public class ReviewServiceImpl implements ReviewService {
 
-	@Autowired
+    @Autowired
     private ReviewRepository reviewRepository;
 
     @Autowired
@@ -44,25 +44,21 @@ public class ReviewServiceImpl implements ReviewService{
 
     @Override
     public ReviewEntity addReview(@Valid RequestReviewDto reviewDto) {
-        ReviewEntity review = new ReviewEntity();
-        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        review.setExperienceId(reviewDto.getExperienceId());
-        review.setRating(reviewDto.getRating());
-        review.setComment(reviewDto.getComment());
-        review.setCreatedAt(new Date());
-        review.setUserId(user.getId());
+        ExperienceEntity experience = experienceRepository.findById(reviewDto.getExperienceId())
+                .orElseThrow(() -> new IllegalArgumentException("No se encontró la experiencia con ID: " + reviewDto.getExperienceId()));
+
+        ReviewEntity review = convertToReviewEntity(reviewDto);
 
         ReviewEntity savedReview = reviewRepository.save(review);
 
         List<ReviewEntity> allReviews = reviewRepository.findByExperienceId(review.getExperienceId());
-        
+
+        // update experience rating
         double sumRatings = allReviews.stream()
                 .mapToDouble(ReviewEntity::getRating)
                 .sum();
         double averageRating = sumRatings / allReviews.size();
 
-        ExperienceEntity experience = experienceRepository.findById(review.getExperienceId())
-                .orElseThrow(() -> new IllegalArgumentException("No se encontró la experiencia con ID: " + review.getExperienceId()));
         experience.setRating(averageRating);
         experienceRepository.save(experience);
 
@@ -88,6 +84,20 @@ public class ReviewServiceImpl implements ReviewService{
         return convertToResponseDto(review);
     }
 
+    private ReviewEntity convertToReviewEntity(RequestReviewDto reviewDto){
+        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        ReviewEntity review = new ReviewEntity();
+
+        review.setExperienceId(reviewDto.getExperienceId());
+        review.setRating(reviewDto.getRating());
+        review.setComment(reviewDto.getComment());
+        review.setCreatedAt(new Date());
+        review.setUserId(user.getId());
+        review.setUserName(user.getName());
+        review.setUserAvatar(user.getAvatar());
+
+        return review;
+    }
 
     private ResponseReviewDto convertToResponseDto(ReviewEntity review) {
         ResponseReviewDto responseDto = new ResponseReviewDto();
@@ -96,6 +106,10 @@ public class ReviewServiceImpl implements ReviewService{
         responseDto.setRating(review.getRating());
         responseDto.setComment(review.getComment());
         responseDto.setCreatedAt(review.getCreatedAt());
+
+        if (review.getUserName() != null) responseDto.setUserName(review.getUserName());
+        if (review.getUserAvatar() != null) responseDto.setUserAvatar(review.getUserAvatar());
+
         return responseDto;
     }
 

--- a/src/test/java/com/igrowker/wander/entityTest/ReviewTest.java
+++ b/src/test/java/com/igrowker/wander/entityTest/ReviewTest.java
@@ -27,12 +27,14 @@ public class ReviewTest {
     void testAllArgsConstructor() {
         // Crear una instancia usando el constructor con todos los argumentos
         Date createdAt = new Date();
-        ReviewEntity review = new ReviewEntity("123", "exp-001", "user-001", 4.5, "Great experience!", createdAt);
+        ReviewEntity review = new ReviewEntity("123", "exp-001", "user-001", "imagen.png", "User Name", 4.5, "Great experience!", createdAt);
 
         // Verificar que los valores se han asignado correctamente
         assertEquals("123", review.getId());
         assertEquals("exp-001", review.getExperienceId());
         assertEquals("user-001", review.getUserId());
+        assertEquals("imagen.png", review.getUserAvatar());
+        assertEquals("User Name", review.getUserName());
         assertEquals(4.5, review.getRating());
         assertEquals("Great experience!", review.getComment());
         assertEquals(createdAt, review.getCreatedAt());


### PR DESCRIPTION
Por petición de front, en las reseñas nuevas almacenamos el `avatar` y `name` del usuario que dejo la reseña para poder desplegarlo luego en la pantalla de reviews de una experiencia. Esta modificación aplicara sobre las nuevas reseñas creadas.