### PR TITLE
Fix: booking date issue

### DIFF
--- a/src/main/java/com/igrowker/wander/dto/booking/RequestBookingDto.java
+++ b/src/main/java/com/igrowker/wander/dto/booking/RequestBookingDto.java
@@ -1,13 +1,15 @@
 package com.igrowker.wander.dto.booking;
 
-import jakarta.validation.constraints.*;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import com.fasterxml.jackson.annotation.JsonFormat;
 
-import java.util.Date;
+import java.time.Instant;
 
 @Data
 @AllArgsConstructor
@@ -15,18 +17,17 @@ import java.util.Date;
 @Builder
 public class RequestBookingDto {
 
-    @NotNull(message = "Experience ID is required")
+    @NotBlank(message = "Experience ID is required")
     private String experienceId;
 
-    @NotNull(message = "Booking date is required")
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "UTC")
-    private Date bookingDate;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+    private Instant bookingDate;
 
     @NotNull(message = "Number of participants is required")
     @Min(value = 1, message = "At least one participant is required")
     private Integer participants;
 
-    @NotNull(message = "User ID is required")
+    @NotBlank(message = "User ID is required")
     private String userId;
 }
 

--- a/src/main/java/com/igrowker/wander/dto/booking/ResponseBookingDto.java
+++ b/src/main/java/com/igrowker/wander/dto/booking/ResponseBookingDto.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
 import java.util.Date;
 
 @Data
@@ -30,9 +31,8 @@ public class ResponseBookingDto {
     @NotNull(message = "Booking status is required")
     private BookingStatus status;
 
-    @NotNull(message = "Booking date is required")
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "UTC")
-    private Date bookingDate;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+    private Instant bookingDate;
 
     @NotNull(message = "Total price is required")
     private double totalPrice;

--- a/src/main/java/com/igrowker/wander/entity/BookingEntity.java
+++ b/src/main/java/com/igrowker/wander/entity/BookingEntity.java
@@ -1,5 +1,6 @@
 package com.igrowker.wander.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.igrowker.wander.entity.enums.PaymentStatus;
 import com.igrowker.wander.entity.enums.BookingStatus;
 import jakarta.validation.constraints.Min;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.Instant;
 import java.util.Date;
 
 @Data
@@ -29,8 +31,8 @@ public class BookingEntity {
     @NotNull(message = "Status is required")
     private BookingStatus status;
 
-    @NotNull(message = "Booking date is required")
-    private Date bookingDate;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+    private Instant bookingDate;
 
     @NotNull(message = "Total price is required")
     @Min(value = 0, message = "Total price must be non-negative")
@@ -43,10 +45,10 @@ public class BookingEntity {
     @NotNull(message = "The payment status cannot be null.")
     private PaymentStatus paymentStatus;
 
-    private Date createdAt;
+    private Date createdAt = new Date();
 
-    public BookingEntity(String experienceId, String userId, BookingStatus status, Date bookingDate,
-                         double totalPrice, Integer participants, PaymentStatus paymentStatus, Date date) {
+    public BookingEntity(String experienceId, String userId, BookingStatus status, Instant bookingDate,
+                         double totalPrice, Integer participants, PaymentStatus paymentStatus) {
         this.experienceId = experienceId;
         this.userId = userId;
         this.status = status;
@@ -54,6 +56,5 @@ public class BookingEntity {
         this.totalPrice = totalPrice;
         this.participants = participants;
         this.paymentStatus = paymentStatus;
-        this.createdAt = new Date();
     }
 }

--- a/src/main/java/com/igrowker/wander/repository/BookingRepository.java
+++ b/src/main/java/com/igrowker/wander/repository/BookingRepository.java
@@ -1,16 +1,13 @@
 package com.igrowker.wander.repository;
 
 import com.igrowker.wander.dto.experience.ExperienceReservationCountDto;
-import com.igrowker.wander.dto.experience.RequestExperienceDto;
 import com.igrowker.wander.entity.BookingEntity;
-import org.bson.Document;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
+import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 
 @EnableMongoRepositories(basePackages = "com.igrowker.wander.repository")
 public interface BookingRepository extends MongoRepository<BookingEntity, String> {
@@ -18,6 +15,8 @@ public interface BookingRepository extends MongoRepository<BookingEntity, String
     List<BookingEntity> findByUserId(String userId);
 
     List<BookingEntity> findByExperienceId(String experienceId);
+
+    List<BookingEntity> findByExperienceIdAndBookingDate(String experienceId, Instant bookingDate);
 
     @Aggregation(pipeline = {
             "{ '$group': { '_id': '$experienceId', 'count': { '$sum': 1 } } }",

--- a/src/main/java/com/igrowker/wander/serviceimpl/BookingServiceImpl.java
+++ b/src/main/java/com/igrowker/wander/serviceimpl/BookingServiceImpl.java
@@ -1,10 +1,9 @@
 package com.igrowker.wander.serviceimpl;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,7 +38,7 @@ public class BookingServiceImpl implements BookingService {
     @Override
     public ResponseBookingDto getBookingById(String id) {
         BookingEntity booking = bookingRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Booking not found with ID: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("No se encontró la reserva con ID: " + id));
         return convertToResponseDto(booking);
     }
 
@@ -62,9 +61,9 @@ public class BookingServiceImpl implements BookingService {
     @Override
     public ResponseBookingDto updateBooking(String id, RequestUpdateBookingDto requestDto) {
         BookingEntity booking = bookingRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Booking not found with ID: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("No se encontró la reserva con ID: " + id));
         User user = userRepository.findById(requestDto.getUserId())
-                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("No se encontró el usuario"));
         validateUserRoleAndUpdateBooking(user, requestDto, booking);
         BookingEntity updatedBooking = bookingRepository.save(booking);
         return convertToResponseDto(updatedBooking);
@@ -73,12 +72,13 @@ public class BookingServiceImpl implements BookingService {
     @Override
     public ResponseBookingDto createBooking(RequestBookingDto requestBookingDto) {
         ExperienceEntity experience = experienceRepository.findById(requestBookingDto.getExperienceId())
-                .orElseThrow(() -> new ResourceNotFoundException("Experience not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("No se encontró la experiencia"));
+
         User user = userRepository.findById(requestBookingDto.getUserId())
-                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("No se encontró el usuario"));
 
         if (!isExperienceAvailable(experience, requestBookingDto.getBookingDate(), requestBookingDto.getParticipants())) {
-            throw new IllegalArgumentException("Experience is not available for the selected date or number of participants");
+            throw new IllegalArgumentException("La experiencia no está disponible para la fecha o el número de participantes seleccionados");
         }
 
         BookingEntity booking = new BookingEntity();
@@ -91,29 +91,48 @@ public class BookingServiceImpl implements BookingService {
         booking.setPaymentStatus(PaymentStatus.PENDING);
 
         BookingEntity savedBooking = bookingRepository.save(booking);
+
         return convertToResponseDto(savedBooking);
     }
 
     private void validateUserRoleAndUpdateBooking(User user, RequestUpdateBookingDto requestDto, BookingEntity booking) {
         if ("TOURIST".equalsIgnoreCase(user.getRole())) {
             if (requestDto.getStatus() != BookingStatus.CANCELLED) {
-                throw new IllegalArgumentException("Tourists can only cancel bookings.");
+                throw new IllegalArgumentException("Los turistas solo pueden cancelar reservas.");
             }
             booking.setStatus(BookingStatus.CANCELLED);
         } else if ("PROVIDER".equalsIgnoreCase(user.getRole())) {
             if (!isProviderStatusValid(requestDto.getStatus())) {
-                throw new IllegalArgumentException("Invalid status for provider.");
+                throw new IllegalArgumentException("Estado inválido para el proveedor.");
             }
             booking.setStatus(requestDto.getStatus());
         } else {
-            throw new InvalidUserCredentialsException("User not authorized to update booking.");
+            throw new InvalidUserCredentialsException("Usuario no autorizado para actualizar la reserva.");
         }
     }
 
-    private boolean isExperienceAvailable(ExperienceEntity experience, @NotNull(message = "Booking date is required") Date bookingDate, int participants) {
+    private boolean isExperienceAvailable(ExperienceEntity experience, Instant bookingDate, int participants) {
+
         boolean isDateAvailable = experience.getAvailabilityDates().stream()
+                .map(Instant::parse)
                 .anyMatch(date -> date.equals(bookingDate));
-        return isDateAvailable && experience.getCapacity() >= participants;
+
+        if (!isDateAvailable) {
+            return false;
+        }
+
+        List<BookingEntity> existingBookings = bookingRepository.findByExperienceIdAndBookingDate(
+                experience.getId(), bookingDate);
+
+        System.out.println(existingBookings);
+
+        int currentCapacity = existingBookings.stream()
+                .mapToInt(BookingEntity::getParticipants)
+                .sum();
+
+        System.out.println(currentCapacity);
+
+        return (experience.getCapacity() - currentCapacity) >= participants;
     }
 
     private double calculateTotalPrice(ExperienceEntity experience, int participants) {


### PR DESCRIPTION
Solucione un problema que teniamos al crear un booking, era un problema de formato de la fecha. La fecha en booking fue cambiada a `Instant`, y sigue el mismo formato que las `availabilityDates` en experience, ejemplo -> `2024-12-15T09:00:00.000Z`.

Ejemplo de petición:
```
{
    "experienceId": "expid123",
    "userId": "userid123",
    "bookingDate": "2024-12-15T09:00:00.000Z",
    "participants": 1
}
```

Anteriormente solo comprobaba que `participants` no sea mayor a la capacidad de la experiencia sin tener en consideración las reservas ya hechas en ese horario. Actualmente la funcion `isExperienceAvailable` en `BookingServiceImpl` comprueba que para la fecha y hora indicados haya disponibilidad teniendo en cuenta otras reservas.