### PR TITLE
Fix: Add tourist, provider and experience title in booking

### DIFF
--- a/src/main/java/com/igrowker/wander/dto/booking/ResponseBookingDto.java
+++ b/src/main/java/com/igrowker/wander/dto/booking/ResponseBookingDto.java
@@ -1,6 +1,7 @@
 package com.igrowker.wander.dto.booking;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.igrowker.wander.dto.user.UserDto;
 import com.igrowker.wander.entity.enums.BookingStatus;
 import com.igrowker.wander.entity.enums.PaymentStatus;
 
@@ -25,8 +26,14 @@ public class ResponseBookingDto {
     @NotNull(message = "Experience ID is required")
     private String experienceId;
 
+    private String experienceTitle;
+
     @NotNull(message = "User ID is required")
     private String userId;
+
+    private UserDto tourist;
+
+    private UserDto provider;
 
     @NotNull(message = "Booking status is required")
     private BookingStatus status;

--- a/src/main/java/com/igrowker/wander/entity/BookingEntity.java
+++ b/src/main/java/com/igrowker/wander/entity/BookingEntity.java
@@ -1,6 +1,7 @@
 package com.igrowker.wander.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.igrowker.wander.dto.user.UserDto;
 import com.igrowker.wander.entity.enums.PaymentStatus;
 import com.igrowker.wander.entity.enums.BookingStatus;
 import jakarta.validation.constraints.Min;
@@ -28,6 +29,10 @@ public class BookingEntity {
     @NotNull(message = "User ID is required")
     private String userId;
 
+    private UserDto touristInfo;
+
+    private UserDto providerInfo;
+
     @NotNull(message = "Status is required")
     private BookingStatus status;
 
@@ -47,10 +52,12 @@ public class BookingEntity {
 
     private Date createdAt = new Date();
 
-    public BookingEntity(String experienceId, String userId, BookingStatus status, Instant bookingDate,
+    public BookingEntity(String experienceId, String userId, UserDto touristInfo, UserDto providerInfo, BookingStatus status, Instant bookingDate,
                          double totalPrice, Integer participants, PaymentStatus paymentStatus) {
         this.experienceId = experienceId;
         this.userId = userId;
+        this.touristInfo = touristInfo;
+        this.providerInfo = providerInfo;
         this.status = status;
         this.bookingDate = bookingDate;
         this.totalPrice = totalPrice;

--- a/src/main/java/com/igrowker/wander/service/UserService.java
+++ b/src/main/java/com/igrowker/wander/service/UserService.java
@@ -7,5 +7,6 @@ import com.igrowker.wander.entity.User;
 public interface UserService {
     UserDto getUserProfile(String id);
     UserDto updateUserProfile(RequestUpdateUserDto userUpdates);
+    UserDto convertToUserDto(User user);
 
 }

--- a/src/main/java/com/igrowker/wander/serviceimpl/UserServiceImpl.java
+++ b/src/main/java/com/igrowker/wander/serviceimpl/UserServiceImpl.java
@@ -98,8 +98,10 @@ public class UserServiceImpl implements UserService {
     }
 
 
-    private UserDto convertToUserDto(User user) {
+    @Override
+    public UserDto convertToUserDto(User user) {
         return UserDto.builder()
+                .id(user.getId())
                 .name(user.getName())
                 .email(user.getEmail())
                 .role(user.getRole())

--- a/src/test/java/com/igrowker/wander/serviceImplTest/BookingServiceImplTest.java
+++ b/src/test/java/com/igrowker/wander/serviceImplTest/BookingServiceImplTest.java
@@ -51,16 +51,28 @@ public class BookingServiceImplTest {
     @Test
     void testGetBookingById_Success() {
         String bookingId = "booking123";
+        String experienceId = "exp123";
+
         BookingEntity booking = new BookingEntity();
         booking.setId(bookingId);
+        booking.setExperienceId(experienceId);
+
+        ExperienceEntity experience = new ExperienceEntity();
+        experience.setId(experienceId);
+        experience.setTitle("Test Experience");
 
         when(bookingRepository.findById(bookingId)).thenReturn(Optional.of(booking));
+        when(experienceRepository.findById(experienceId)).thenReturn(Optional.of(experience));
 
         ResponseBookingDto result = bookingService.getBookingById(bookingId);
 
         assertNotNull(result);
         assertEquals(bookingId, result.getId());
+        assertEquals(experienceId, result.getExperienceId());
+        assertEquals("Test Experience", result.getExperienceTitle());
+
         verify(bookingRepository, times(1)).findById(bookingId);
+        verify(experienceRepository, times(1)).findById(experienceId);
     }
 
     @Test
@@ -119,10 +131,16 @@ public class BookingServiceImplTest {
     void testUpdateBooking_TouristCancel_Success() {
         String bookingId = "booking123";
         String userId = "user123";
+        String experienceId = "exp123";
 
         BookingEntity booking = new BookingEntity();
         booking.setId(bookingId);
+        booking.setExperienceId(experienceId);
         booking.setStatus(BookingStatus.PENDING);
+
+        ExperienceEntity experience = new ExperienceEntity();
+        experience.setId(experienceId);
+        experience.setTitle("Titulo de experiencia de prueba");
 
         User user = new User();
         user.setId(userId);
@@ -134,6 +152,7 @@ public class BookingServiceImplTest {
 
         when(bookingRepository.findById(bookingId)).thenReturn(Optional.of(booking));
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(experienceRepository.findById(experienceId)).thenReturn(Optional.of(experience));
         when(bookingRepository.save(any(BookingEntity.class))).thenReturn(booking);
 
         ResponseBookingDto result = bookingService.updateBooking(bookingId, request);
@@ -142,6 +161,7 @@ public class BookingServiceImplTest {
         assertEquals(BookingStatus.CANCELLED, result.getStatus());
         verify(bookingRepository, times(1)).findById(bookingId);
         verify(userRepository, times(1)).findById(userId);
+        verify(experienceRepository, times(1)).findById(experienceId);
         verify(bookingRepository, times(1)).save(any(BookingEntity.class));
     }
 


### PR DESCRIPTION
Este PR realiza una serie de cambios y mejoras en la funcionalidad de reservas (booking).
- Se ha actualizado el DTO `ResponseBookingDto` para incluir el titulo de la experiencia, info del turista y del proveedor. 
- Se ha actualizado la entidad Booking para que incluya info del turista  y del proveedor.
- Los cambios se han manejado en el servicio.

## Notas
- Se hicieron cambios en dos casos de test para que no fallaran. El cambio en el metodo `convertToResponseDto` los hacia fallar.
- Con esas modificaciones no falla ningún test. 


