### PR TITLE
Feature: Add functionality to get available slots per date

### DIFF
--- a/src/main/java/com/igrowker/wander/controller/ExperienceController.java
+++ b/src/main/java/com/igrowker/wander/controller/ExperienceController.java
@@ -1,5 +1,6 @@
 package com.igrowker.wander.controller;
 
+import com.igrowker.wander.dto.experience.ResponseExperienceWithSlotsDto;
 import com.igrowker.wander.dto.experience.RequestExperienceDto;
 import com.igrowker.wander.dto.experience.ResponseExperienceDto;
 import com.igrowker.wander.entity.ExperienceEntity;
@@ -12,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Collections;
 import java.util.List;
 
 import javax.validation.Valid;
@@ -61,10 +61,10 @@ public class ExperienceController {
 
 
 	@GetMapping("/{id}")
-	public ResponseEntity<ExperienceEntity> getExperienceById(@PathVariable String id) {
+	public ResponseEntity<ResponseExperienceWithSlotsDto> getExperienceByIdWithSlots(@PathVariable String id) {
 		try {
-			ExperienceEntity experience = experienceService.getExperienceById(id);
-			return ResponseEntity.ok(experience);
+			ResponseExperienceWithSlotsDto experienceWithSlots = experienceService.getExperienceByIdWithSlots(id);
+			return ResponseEntity.ok(experienceWithSlots);
 		} catch (IllegalArgumentException e) {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
 		} catch (Exception e) {

--- a/src/main/java/com/igrowker/wander/dto/experience/AvailabilityDateWithSlotsDto.java
+++ b/src/main/java/com/igrowker/wander/dto/experience/AvailabilityDateWithSlotsDto.java
@@ -1,0 +1,13 @@
+package com.igrowker.wander.dto.experience;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AvailabilityDateWithSlotsDto {
+    private String date;
+    private int availableSlots;
+}

--- a/src/main/java/com/igrowker/wander/dto/experience/ResponseExperienceWithSlotsDto.java
+++ b/src/main/java/com/igrowker/wander/dto/experience/ResponseExperienceWithSlotsDto.java
@@ -1,0 +1,26 @@
+package com.igrowker.wander.dto.experience;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseExperienceWithSlotsDto {
+    private String id;
+    private String title;
+    private String description;
+    private List<String> location;
+    private String hostId;
+    private Double price;
+    private List<AvailabilityDateWithSlotsDto> availabilityDatesWithSlots;
+    private List<String> tags;
+    private Double rating;
+    private int capacity;
+    private Date createdAt;
+    private boolean status;
+}

--- a/src/main/java/com/igrowker/wander/service/ExperienceService.java
+++ b/src/main/java/com/igrowker/wander/service/ExperienceService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.igrowker.wander.dto.experience.RequestExperienceDto;
 import com.igrowker.wander.dto.experience.ResponseExperienceDto;
+import com.igrowker.wander.dto.experience.ResponseExperienceWithSlotsDto;
 import com.igrowker.wander.entity.ExperienceEntity;
 import com.igrowker.wander.entity.User;
 
@@ -29,5 +30,7 @@ public interface ExperienceService {
     List<ExperienceEntity> getExperiencesByMultipleTags(List<String> tags);
 
     List<ResponseExperienceDto> getExperiencesByHost(String hostId);
+
+    ResponseExperienceWithSlotsDto getExperienceByIdWithSlots(String id);
 
 }


### PR DESCRIPTION
Este PR implementa la funcionalidad de mostrar la disponibilidad de cupos para cada fecha de una experiencia al consultar la información a través de la API. 

   - El  endpoint `GET /experiences/{id}`ahora devuelve `ResponseExperienceWithSlotsDto` para incluir un campo `availabilityDatesWithSlots`, que contiene las fechas de disponibilidad junto con la cantidad de cupos disponibles para cada una.
   - Se ha implementado el método `calculateAvailableSlotsForDate`, que realiza la suma de participantes reservados para una fecha dada y calcula los cupos disponibles.
   
### Notas
- Al realizar una reserva (`POST /bookings`), la cantidad de cupos disponibles de la experiencia se actualiza correctamente.
- Se verificó que la respuesta del `GET /experiences/{id}` refleja los cambios en los cupos disponibles después de realizar una reserva.
- Se corrieron los test para verificar que no fallaran.

