### PR TITLE
Fix: experience filter wasn't working by one filter

### DIFF
--- a/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
+++ b/src/main/java/com/igrowker/wander/serviceimpl/ExperienceServiceImpl.java
@@ -82,7 +82,7 @@ public class ExperienceServiceImpl implements ExperienceService {
             results = experienceRepository.findByCountry(country);
         } else {
             // Filtro: Si solo queda `location` genérico
-            results = experienceRepository.findByLocationContains(location);
+            results = experienceRepository.findAll();
         }
 
         // Filtro adicional: Tags


### PR DESCRIPTION
Modifique una linea para que en caso de no pasarle location devuelva todas las experiencias, y que luego realice el filtrado en caso de ser necesario. Porque antes en caso de no pasarle location devolvia un array vacio.